### PR TITLE
Update CPAN::DistnameInfo, CPAN::PackageDetails, Carton, Cwd, File::Copy::Recursive, File::Spec::Functions, IO::String, JSON, LWP::UserAgent, List::Util, Module::CPANfile, Module::CPANfile::Writer, Module::CoreList, Path::Class, Test2::V0, Test::WWW::Stub

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,25 +1,25 @@
 requires 'perl', '5.010001';
 
-requires 'Module::CPANfile';
-requires 'Module::CPANfile::Writer';
-requires 'CPAN::PackageDetails';
-requires 'CPAN::DistnameInfo';
-requires 'LWP::UserAgent';
-requires 'IO::String';
+requires 'Module::CPANfile', '== 1.1004';
+requires 'Module::CPANfile::Writer', '== 0.01';
+requires 'CPAN::PackageDetails', '== 0.263';
+requires 'CPAN::DistnameInfo', '== 0.12';
+requires 'LWP::UserAgent', '== 6.54';
+requires 'IO::String', '== 1.08';
 requires 'Getopt::Long';
-requires 'Carton';
+requires 'Carton', '== 1.000034';
 requires 'CPAN::Meta::Prereqs', '>= 2.150010';
-requires 'JSON';
-requires 'List::Util';
+requires 'JSON', '== 4.03';
+requires 'List::Util', '== 1.56';
 
 on 'test' => sub {
-    requires 'Test2::V0';
-    requires 'Cwd';
+    requires 'Test2::V0', '== 0.000140';
+    requires 'Cwd', '== 3.75';
     requires 'FindBin';
-    requires 'File::Spec::Functions';
+    requires 'File::Spec::Functions', '== 3.75';
     requires 'File::Temp';
-    requires 'File::Copy::Recursive';
-    requires 'Path::Class';
-    requires 'Test::WWW::Stub';
-    requires 'Module::CoreList', '>= 5.20200717';
+    requires 'File::Copy::Recursive', '== 0.45';
+    requires 'Path::Class', '== 0.37';
+    requires 'Test::WWW::Stub', '== 0.10';
+    requires 'Module::CoreList', '== 5.20210521';
 };


### PR DESCRIPTION
- [CPAN::DistnameInfo](https://metacpan.org/pod/CPAN::DistnameInfo) == 0.12 ([Changes](https://metacpan.org/changes/distribution/CPAN-DistnameInfo))
- [CPAN::PackageDetails](https://metacpan.org/pod/CPAN::PackageDetails) == 0.263 ([Changes](https://metacpan.org/changes/distribution/CPAN-PackageDetails))
- [Carton](https://metacpan.org/pod/Carton) == 1.000034 ([Changes](https://metacpan.org/changes/distribution/Carton))
- [Cwd](https://metacpan.org/pod/Cwd) == 3.75 ([Changes](https://metacpan.org/changes/distribution/PathTools))
- [File::Copy::Recursive](https://metacpan.org/pod/File::Copy::Recursive) == 0.45 ([Changes](https://metacpan.org/changes/distribution/File-Copy-Recursive))
- [File::Spec::Functions](https://metacpan.org/pod/File::Spec::Functions) == 3.75 ([Changes](https://metacpan.org/changes/distribution/PathTools))
- [IO::String](https://metacpan.org/pod/IO::String) == 1.08 ([Changes](https://metacpan.org/changes/distribution/IO-String))
- [JSON](https://metacpan.org/pod/JSON) == 4.03 ([Changes](https://metacpan.org/changes/distribution/JSON))
- [LWP::UserAgent](https://metacpan.org/pod/LWP::UserAgent) == 6.54 ([Changes](https://metacpan.org/changes/distribution/libwww-perl))
- [List::Util](https://metacpan.org/pod/List::Util) == 1.56 ([Changes](https://metacpan.org/changes/distribution/Scalar-List-Utils))
- [Module::CPANfile](https://metacpan.org/pod/Module::CPANfile) == 1.1004 ([Changes](https://metacpan.org/changes/distribution/Module-CPANfile))
- [Module::CPANfile::Writer](https://metacpan.org/pod/Module::CPANfile::Writer) == 0.01 ([Changes](https://metacpan.org/changes/distribution/Module-CPANfile-Writer))
- [Module::CoreList](https://metacpan.org/pod/Module::CoreList) == 5.20210521 ([Changes](https://metacpan.org/changes/distribution/Module-CoreList))
- [Path::Class](https://metacpan.org/pod/Path::Class) == 0.37 ([Changes](https://metacpan.org/changes/distribution/Path-Class))
- [Test2::V0](https://metacpan.org/pod/Test2::V0) == 0.000140 ([Changes](https://metacpan.org/changes/distribution/Test2-Suite))
- [Test::WWW::Stub](https://metacpan.org/pod/Test::WWW::Stub) == 0.10 ([Changes](https://metacpan.org/changes/distribution/Test-WWW-Stub))
Automated changes by [update-cpanfile](https://metacpan.org/pod/distribution/App-UpdateCPANfile/script/update-cpanfile) version 1.1.1